### PR TITLE
fix: Replace hardcoded /home/david paths with $HOME variable

### DIFF
--- a/scripts/deploy-enhanced.sh
+++ b/scripts/deploy-enhanced.sh
@@ -8,7 +8,7 @@ set -u  # Exit on undefined variable
 
 # ========== CONFIGURATION ==========
 # These can be overridden with environment variables
-MCP_SERVER_DIR="${MCP_SERVER_DIR:-/home/david/.local/lib/browsermcp-enhanced}"
+MCP_SERVER_DIR="${MCP_SERVER_DIR:-$HOME/.local/lib/browsermcp-enhanced}"
 CHROME_EXT_DIR="${CHROME_EXT_DIR:-$MCP_SERVER_DIR/chrome-extension}"
 BACKUP_DIR="${BACKUP_DIR:-$HOME/.local/backups/browsermcp-enhanced}"
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/deploy-firefox
+++ b/scripts/deploy-firefox
@@ -7,7 +7,7 @@ set -e  # Exit on error
 set -u  # Exit on undefined variable
 
 # ========== CONFIGURATION ==========
-MCP_SERVER_DIR="${MCP_SERVER_DIR:-/home/david/.local/lib/browsermcp-enhanced}"
+MCP_SERVER_DIR="${MCP_SERVER_DIR:-$HOME/.local/lib/browsermcp-enhanced}"
 FIREFOX_EXT_DIR="${FIREFOX_EXT_DIR:-$MCP_SERVER_DIR/firefox-extension}"
 CHROME_EXT_DIR="${CHROME_EXT_DIR:-$MCP_SERVER_DIR/chrome-extension}"
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,8 +13,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-MCP_SERVER_DIR="/home/david/.local/lib/browsermcp-enhanced"
-CHROME_EXT_DIR="/home/david/.local/lib/browsermcp-enhanced/chrome-extension"
+MCP_SERVER_DIR="${MCP_SERVER_DIR:-$HOME/.local/lib/browsermcp-enhanced}"
+CHROME_EXT_DIR="${CHROME_EXT_DIR:-$MCP_SERVER_DIR/chrome-extension}"
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPTS_DIR="$CURRENT_DIR/scripts"
 

--- a/scripts/force-reload-extension.sh
+++ b/scripts/force-reload-extension.sh
@@ -14,7 +14,7 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 
 EXTENSION_ID="YOUR_EXTENSION_ID" # Will be detected
-CHROME_EXT_DIR="/home/david/.local/lib/browsermcp-enhanced/chrome-extension"
+CHROME_EXT_DIR="${CHROME_EXT_DIR:-$HOME/.local/lib/browsermcp-enhanced/chrome-extension}"
 
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}Chrome Extension Force Reload Script${NC}"

--- a/src/hot-reload.ts
+++ b/src/hot-reload.ts
@@ -37,7 +37,7 @@ const DEFAULT_OPTIONS: Required<HotReloadOptions> = {
 
 // SECURITY: Deploy path configuration with validation
 const DEPLOY_BASE_PATH = process.env.BROWSERMCP_DEPLOY_PATH ||
-                         '/home/david/.local/lib/browsermcp-enhanced';
+                         path.join(process.env.HOME || '', '.local/lib/browsermcp-enhanced');
 
 let isReloading = false;
 let debounceTimer: NodeJS.Timeout | null = null;

--- a/src/index-http.ts
+++ b/src/index-http.ts
@@ -81,7 +81,7 @@ program
     // Enable hot reload in development mode
     if (process.env.NODE_ENV === 'development' || process.env.HOT_RELOAD === 'true') {
       console.error('[BrowserMCP HTTP] Hot reload enabled - edit any .ts file to trigger rebuild and respawn');
-      const watchPath = process.env.HOT_RELOAD_WATCH_PATH || '/home/david/Work/Programming/browsermcp-enhanced/src';
+      const watchPath = process.env.HOT_RELOAD_WATCH_PATH || process.cwd() + '/src';
       console.error(`[BrowserMCP HTTP] Watching: ${watchPath}`);
       enableHotReload({
         verbose: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ program
     // Enable hot reload in development mode
     if (process.env.NODE_ENV === 'development' || process.env.HOT_RELOAD === 'true') {
       console.error('[BrowserMCP] Hot reload enabled - edit any .ts file to trigger rebuild and respawn');
-      const watchPath = process.env.HOT_RELOAD_WATCH_PATH || '/home/david/Work/Programming/browsermcp-enhanced/src';
+      const watchPath = process.env.HOT_RELOAD_WATCH_PATH || process.cwd() + '/src';
       console.error(`[BrowserMCP] Watching: ${watchPath}`);
       enableHotReload({
         verbose: true,


### PR DESCRIPTION
## Summary
Replaces all hardcoded `/home/david` paths with portable `$HOME` environment variable to make the project work across different user environments.

## Changes
- **Deployment scripts**: Updated all scripts to use `$HOME` instead of hardcoded paths
  - `scripts/deploy-enhanced.sh`
  - `scripts/deploy-firefox`
  - `scripts/deploy.sh`
  - `scripts/force-reload-extension.sh`
- **TypeScript source files**: Use `process.env.HOME` and `process.cwd()` for dynamic paths
  - `src/hot-reload.ts`
  - `src/index-http.ts`
  - `src/index.ts`

## Benefits
✅ Portable across different user environments  
✅ Maintains backward compatibility with environment variable overrides  
✅ No breaking changes - paths still configurable via env vars

## Testing
- ✅ Tested successful deployment on different user account
- ✅ All scripts maintain same functionality with dynamic paths
- ✅ Build completes successfully with updated paths