### PR TITLE
feat: Enable remote server connections with comprehensive error handling

### DIFF
--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -162,20 +162,40 @@
   <button id="connect">Connect Current Tab</button>
 
   <div class="settings">
-    <div class="setting-item">
-      <span class="setting-label">Multi-Instance Mode</span>
-      <label class="toggle">
-        <input type="checkbox" id="multi-instance-toggle">
-        <span class="slider"></span>
-      </label>
+    <h4 style="margin-top: 0; margin-bottom: 10px; font-size: 14px; color: #555;">Server Configuration</h4>
+
+    <div class="server-config">
+      <label for="server-host" style="font-size: 12px; color: #666; display: block; margin-bottom: 3px;">Host:</label>
+      <input type="text" id="server-host" placeholder="localhost" style="width: 100%; padding: 6px; border: 1px solid #ddd; border-radius: 3px; font-size: 13px; margin-bottom: 8px;">
+
+      <label for="server-port" style="font-size: 12px; color: #666; display: block; margin-bottom: 3px;">Port:</label>
+      <input type="number" id="server-port" placeholder="8765" min="1" max="65535" style="width: 100%; padding: 6px; border: 1px solid #ddd; border-radius: 3px; font-size: 13px; margin-bottom: 8px;">
+
+      <button id="save-server-config" style="background: #28a745; margin-top: 5px;">Save & Reconnect</button>
+
+      <div id="server-info" style="font-size: 11px; color: #666; margin-top: 8px; padding: 5px; background: #f9f9f9; border-radius: 3px;">
+        Current: <span id="current-server">localhost:8765</span>
+      </div>
     </div>
 
-    <div class="setting-item">
-      <span class="setting-label">Unsafe Mode</span>
-      <label class="toggle">
-        <input type="checkbox" id="unsafe-mode-toggle">
-        <span class="slider"></span>
-      </label>
+    <div style="border-top: 1px solid #ddd; margin: 15px 0; padding-top: 15px;">
+      <h4 style="margin-top: 0; margin-bottom: 10px; font-size: 14px; color: #555;">Options</h4>
+
+      <div class="setting-item">
+        <span class="setting-label">Multi-Instance Mode</span>
+        <label class="toggle">
+          <input type="checkbox" id="multi-instance-toggle">
+          <span class="slider"></span>
+        </label>
+      </div>
+
+      <div class="setting-item">
+        <span class="setting-label">Unsafe Mode</span>
+        <label class="toggle">
+          <input type="checkbox" id="unsafe-mode-toggle">
+          <span class="slider"></span>
+        </label>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
This PR adds support for configurable remote server connections in the browser extension, allowing users to connect to MCP servers on different hosts/ports instead of hardcoded localhost:8765.

## Key Features

### 1. Configurable Server Settings
- Added UI in extension popup for server configuration
- Host and port input fields with validation
- Save & Reconnect functionality
- Persistent storage in chrome.storage.local
- Real-time server display in popup

### 2. Comprehensive Error Handling
- Detailed WebSocket error tracking and classification
  - Code 1006: Connection refused (server not running)
  - Code 1002: Protocol error
  - Code 1000: Clean disconnect
- Error messages persist across popup refreshes
- Badge tooltip shows error details and timestamp
- User-friendly status messages:
  - "Disconnected" for clean disconnects
  - "Connection Error" with details for failures

### 3. Improved Connection Management
- Fixed popup communication with background worker
- Manual close flag prevents auto-reconnect conflicts
- Enhanced reloadConfig with proper cleanup
- Extended connection timeout (2.5s) for reliable reconnects
- Clear error state on new connection attempts

## Technical Changes

**Modified Files:**
- `chrome-extension/unified-connection-manager.js` (+82 lines)
  - Added loadServerConfig() for dynamic configuration
  - Enhanced error tracking (lastError, lastErrorTime)
  - Improved WebSocket event handlers
  - Added reloadConfig() method

- `chrome-extension/popup.html` (+44 lines)
  - Server configuration form
  - Host/port input fields
  - Current server display

- `chrome-extension/popup.js` (+54 lines)
  - Config load/save handlers
  - Error persistence logic
  - Improved status display

- `chrome-extension/background-daemon.js` (+17 lines)
  - Popup message handlers (getStatus, reloadServerConfig)
  - Error info propagation

## User Impact

✅ Connect to remote MCP servers (dev/staging/production) ✅ See exactly what went wrong when connection fails ✅ Errors don't disappear during reconnection attempts ✅ Hover extension icon for detailed error information ✅ Save & Reconnect works reliably without conflicts

## Testing

Tested scenarios:
- ✅ Save localhost:8765 and reconnect
- ✅ Save non-existent port (e.g., localhost:8766) - shows error
- ✅ Error persists across popup close/reopen
- ✅ Clean disconnect shows "Disconnected"
- ✅ Connection error shows "Connection Error" with details